### PR TITLE
[RIAL-1134] BatchCancelOrder Transition added

### DIFF
--- a/contracts/fixed_price.scilla
+++ b/contracts/fixed_price.scilla
@@ -1126,19 +1126,6 @@ end
 procedure DoBatchCancelOrder(order: CancelOrderParam)  
   match order with
   | CancelOrderParam token_address token_id payment_token_address sale_price side =>
-    cur_owner <- contract_owner;
-    is_contract_owner = builtin eq cur_owner _sender;
-    cur_operator <- operator;
-    is_operator = builtin eq cur_operator _sender;
-    is_owner_operator = orb is_contract_owner is_operator;
-    match is_owner_operator with
-    | True => 
-      (* the contract owner/operator can cancel orders only if this contract is paused. *)
-      RequirePaused
-    | False =>
-      (* - the makers can cancel their orders only if this contract is not paused. *)
-      RequireNotPaused
-    end;
     Cancel token_address token_id payment_token_address sale_price side
   end
 end
@@ -1325,6 +1312,19 @@ end
 
 (* Batch cancel order *)
 transition BatchCancelOrder(cancel_order_list: List CancelOrderParam)
+  cur_owner <- contract_owner;
+  is_contract_owner = builtin eq cur_owner _sender;
+  cur_operator <- operator;
+  is_operator = builtin eq cur_operator _sender;
+  is_owner_operator = orb is_contract_owner is_operator;
+  match is_owner_operator with
+  | True => 
+    (* the contract owner/operator can cancel orders only if this contract is paused. *)
+    RequirePaused
+  | False =>
+    (* - the makers can cancel their orders only if this contract is not paused. *)
+    RequireNotPaused
+  end;
   forall cancel_order_list DoBatchCancelOrder
 end
 

--- a/contracts/fixed_price.scilla
+++ b/contracts/fixed_price.scilla
@@ -1123,17 +1123,17 @@ procedure Cancel(
   end
 end
 
-procedure BatchCancelOrder_(order: CancelOrderParam)  
+procedure DoBatchCancelOrder(order: CancelOrderParam)  
   match order with
   | CancelOrderParam token_address token_id payment_token_address sale_price side =>
     cur_owner <- contract_owner;
     is_contract_owner = builtin eq cur_owner _sender;
     cur_operator <- operator;
     is_operator = builtin eq cur_operator _sender;
-    is_valid = orb is_contract_owner is_operator;
-    match is_valid with
+    is_owner_operator = orb is_contract_owner is_operator;
+    match is_owner_operator with
     | True => 
-      (* the contract owner can cancel orders only if this contract is paused. *)
+      (* the contract owner/operator can cancel orders only if this contract is paused. *)
       RequirePaused
     | False =>
       (* - the makers can cancel their orders only if this contract is not paused. *)
@@ -1309,11 +1309,11 @@ transition CancelOrder(
   is_contract_owner = builtin eq cur_owner _sender;
   cur_operator <- operator;
   is_operator = builtin eq cur_operator _sender;
-  is_valid = orb is_contract_owner is_operator;
+  is_owner_operator = orb is_contract_owner is_operator;
   
-  match is_valid with
+  match is_owner_operator with
   | True => 
-    (* the contract owner can cancel orders only if this contract is paused. *)
+    (* the contract owner/operator can cancel orders only if this contract is paused. *)
     RequirePaused
   | False =>
     (* - the makers can cancel their orders only if this contract is not paused. *)
@@ -1325,7 +1325,7 @@ end
 
 (* Batch cancel order *)
 transition BatchCancelOrder(cancel_order_list: List CancelOrderParam)
-  forall cancel_order_list BatchCancelOrder_
+  forall cancel_order_list DoBatchCancelOrder
 end
 
 (* @multi-sig *)
@@ -1445,6 +1445,14 @@ transition SetOperator(to: ByStr20)
   RequireValidDestination to;
   operator := to;
   e = { _eventname: "UpdatedOperator"; operator: to };
+  event e
+end
+
+(* @multi-sig *)
+transition ClearOperator()
+  RequireContractOwner;
+  operator := zero_address;
+  e = { _eventname: "ClearOperator" };
   event e
 end
 

--- a/contracts/fixed_price.scilla
+++ b/contracts/fixed_price.scilla
@@ -212,7 +212,7 @@ let make_error =
       | InvalidSignature                   => Int32 -22
       | OrderNotAuthorized                 => Int32 -23
       | OrderExpired                       => Int32 -24
-      | InvalidVerifier                    => Int32 -25  
+      | InvalidVerifier                    => Int32 -25
       | NotSignedOrderModeEnabled          => Int32 -26
       | NotSignedOrderModeDisabled         => Int32 -27
 
@@ -291,6 +291,9 @@ field is_signed_order_mode: Bool = false
 (* Public key used to verify signed fulfill order *)
 field verifier_pub_key : ByStr33 = zero_pubkey
 
+(* Batchcancel Operator *)
+(* Defaults to `zero_address` *)
+field operator: ByStr20 = zero_address
 
 (* Procedures *)
 procedure Throw(error : Error)
@@ -435,9 +438,13 @@ end
 procedure RequireAccessToCancel(maker_address: ByStr20)
   cur_owner <- contract_owner;
   is_contract_owner = builtin eq cur_owner _sender;
+  cur_operator <- operator;
+  is_operator = builtin eq cur_operator _sender;
   is_maker = builtin eq maker_address _sender;
+  is_maker_owner = orb is_maker is_contract_owner;
+  is_operator_owner = orb is_maker is_operator;
+  is_allowed_to_cancel_order = orb is_maker_owner is_operator_owner;
 
-  is_allowed_to_cancel_order = orb is_maker is_contract_owner;
   match is_allowed_to_cancel_order with
   | True =>
   | False =>
@@ -1116,12 +1123,15 @@ procedure Cancel(
   end
 end
 
-procedure BatchCancelOrder_(order: CancelOrderParam)
+procedure BatchCancelOrder_(order: CancelOrderParam)  
   match order with
   | CancelOrderParam token_address token_id payment_token_address sale_price side =>
     cur_owner <- contract_owner;
     is_contract_owner = builtin eq cur_owner _sender;
-    match is_contract_owner with
+    cur_operator <- operator;
+    is_operator = builtin eq cur_operator _sender;
+    is_valid = orb is_contract_owner is_operator;
+    match is_valid with
     | True => 
       (* the contract owner can cancel orders only if this contract is paused. *)
       RequirePaused
@@ -1297,8 +1307,11 @@ transition CancelOrder(
 )
   cur_owner <- contract_owner;
   is_contract_owner = builtin eq cur_owner _sender;
+  cur_operator <- operator;
+  is_operator = builtin eq cur_operator _sender;
+  is_valid = orb is_contract_owner is_operator;
   
-  match is_contract_owner with
+  match is_valid with
   | True => 
     (* the contract owner can cancel orders only if this contract is paused. *)
     RequirePaused
@@ -1312,7 +1325,6 @@ end
 
 (* Batch cancel order *)
 transition BatchCancelOrder(cancel_order_list: List CancelOrderParam)
-  RequireAllowedUser _sender;
   forall cancel_order_list BatchCancelOrder_
 end
 
@@ -1424,6 +1436,15 @@ transition SetAllowlist(
     _eventname: "SetAllowlist";
     address: address
   };
+  event e
+end
+
+(* @multi-sig *)
+transition SetOperator(to: ByStr20)
+  RequireContractOwner;
+  RequireValidDestination to;
+  operator := to;
+  e = { _eventname: "UpdatedOperator"; operator: to };
   event e
 end
 

--- a/contracts/fixed_price.scilla
+++ b/contracts/fixed_price.scilla
@@ -143,6 +143,16 @@ field spenders: Map Uint256 ByStr20,
 field token_owners: Map Uint256 ByStr20 
 end Uint256 ByStr20 Uint128 Uint32 BNum
 
+(* for batch cancel transitions *)
+(* token_address, token_id, payment_token_address, sale_price, side *)
+type CancelOrderParam =
+| CancelOrderParam of ByStr20 with contract 
+  field royalty_recipient: ByStr20, 
+  field royalty_fee_bps: Uint128, 
+  field spenders: Map Uint256 ByStr20, 
+  field token_owners: Map Uint256 ByStr20 
+end Uint256 ByStr20 Uint128 Uint32
+
 (* Error exceptions *)
 type Error =
   | NotContractOwnerError
@@ -1106,6 +1116,23 @@ procedure Cancel(
   end
 end
 
+procedure BatchCancelOrder_(order: CancelOrderParam)
+  match order with
+  | CancelOrderParam token_address token_id payment_token_address sale_price side =>
+    cur_owner <- contract_owner;
+    is_contract_owner = builtin eq cur_owner _sender;
+    match is_contract_owner with
+    | True => 
+      (* the contract owner can cancel orders only if this contract is paused. *)
+      RequirePaused
+    | False =>
+      (* - the makers can cancel their orders only if this contract is not paused. *)
+      RequireNotPaused
+    end;
+    Cancel token_address token_id payment_token_address sale_price side
+  end
+end
+
 (* Sets sell and buy orders. *)
 (* - Sellers can set sell orders (listings) *)
 (* - Buyers can set buy orders (offers) *)
@@ -1281,6 +1308,12 @@ transition CancelOrder(
   end;
 
   Cancel token_address token_id payment_token_address sale_price side
+end
+
+(* Batch cancel order *)
+transition BatchCancelOrder(cancel_order_list: List CancelOrderParam)
+  RequireAllowedUser _sender;
+  forall cancel_order_list BatchCancelOrder_
 end
 
 (* @multi-sig *)

--- a/tests/fixedPrice.test.js
+++ b/tests/fixedPrice.test.js
@@ -19,9 +19,6 @@ const { bytes } = require('@zilliqa-js/util');
 var EC = require('elliptic').ec;
 const { SHA256, enc } = require('crypto-js')
 
-
-
-
 const zero_address = "0x0000000000000000000000000000000000000000"
 const zero_pubkey = "0x000000000000000000000000000000000000000000000000000000000000000000"
 
@@ -346,7 +343,7 @@ beforeEach(async () => {
       {
         vname: 'amount',
         type: "Uint128",
-        value: String(100 * 1000),
+        value: String(1000 * 1000),
       }
     ],
     0,
@@ -368,7 +365,7 @@ beforeEach(async () => {
       {
         vname: 'amount',
         type: "Uint128",
-        value: String(100 * 1000),
+        value: String(1000 * 1000),
       }
     ],
     0,
@@ -390,7 +387,7 @@ beforeEach(async () => {
       {
         vname: 'amount',
         type: "Uint128",
-        value: String(100 * 1000),
+        value: String(1000 * 1000),
       }
     ],
     0,
@@ -473,6 +470,22 @@ async function createFixedPriceOrder(
     constructor: `${fixedPriceContractAddress.toLowerCase()}.OrderParam`,
     argtypes: [],
     arguments: [tokenAddress, tokenId, paymentTokenAddress, salePrice, side, expirationBnum]
+  }
+}
+
+async function createBatchCancelOrder(
+  fixedPriceContractAddress,
+  tokenAddress,
+  tokenId,
+  paymentTokenAddress,
+  salePrice,
+  side,
+  expirationBnum
+) {
+  return {
+    constructor: `${fixedPriceContractAddress.toLowerCase()}.CancelOrderParam`,
+    argtypes: [],
+    arguments: [tokenAddress, tokenId, paymentTokenAddress, salePrice, side]
   }
 }
 
@@ -2618,6 +2631,745 @@ describe('Native ZIL', () => {
 
   })
 
+  test('BatchCancelOrder: Seller cancels sell orders', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+
+    const side = String(0)
+
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      zero_address,
+      '100000',
+      side,
+      String(globalBNum + 35)
+    )
+  
+    const txSetOrder1 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      0,
+      false,
+      false
+    )
+  
+    console.log("BatchCancelOrder: Seller cancels sell orders - 1",txSetOrder1.receipt)
+    expect(txSetOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      zero_address,
+      '200000',
+      side,
+      String(globalBNum + 35)
+    )
+
+    const txSetOrder2 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Seller cancels sell orders - 2", txSetOrder2.receipt)
+    expect(txSetOrder2.receipt.success).toEqual(true)
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      zero_address,
+      "100000",
+      side
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      zero_address,
+      "200000",
+      side
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    const tx = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Seller cancels sell orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(true)
+
+    let events = tx.receipt.event_logs;
+    expect(events.length).toEqual(2)
+
+    expect(events[0]._eventname == 'CancelOrder').toEqual(true);
+    expect(events[1]._eventname == 'CancelOrder').toEqual(true);
+
+    expect(events[0].params[0].value).toEqual(accounts.nftSeller.address.toLowerCase())
+    expect(events[0].params[5].value).toEqual("200000")
+
+    expect(events[1].params[0].value).toEqual(accounts.nftSeller.address.toLowerCase())
+    expect(events[1].params[5].value).toEqual("100000")
+
+  })
+
+  test('BatchCancelOrder: Stranger cancels sell orders throw NotAllowedToCancelOrder Error', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+
+    const side = String(0)
+
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      zero_address,
+      '100000',
+      side,
+      String(globalBNum + 35)
+    )
+  
+    const txSetOrder1 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      0,
+      false,
+      false
+    )
+  
+    console.log("BatchCancelOrder: Stranger cancels sell orders - 1",txSetOrder1.receipt)
+    expect(txSetOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      zero_address,
+      '200000',
+      side,
+      String(globalBNum + 35)
+    )
+
+    const txSetOrder2 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Stranger cancels sell orders - 2", txSetOrder2.receipt)
+    expect(txSetOrder2.receipt.success).toEqual(true)
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      zero_address,
+      "100000",
+      side
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      zero_address,
+      "200000",
+      side
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    const tx = await callContract(
+      accounts.stranger.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Stranger cancels sell orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(false)
+    expect(tx.receipt.exceptions).toEqual([
+      {
+        line: 1,
+        message: 'Exception thrown: (Message [(_exception : (String "Error")) ; (code : (Int32 -12))])'
+      },
+      { line: 1, message: 'Raised from RequireNotPaused' },
+      { line: 1, message: 'Raised from RequireAllowedUser' },
+      { line: 1, message: 'Raised from BatchCancelOrder' }
+    ])
+  })
+
+  test('BatchCancelOrder: Buyer cancels buy orders', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+    const fixedPriceStartingBalance = await getBalance(fixedPriceAddress)
+
+    const side = String(1)
+    const expiryBlock = String(globalBNum + 35)
+
+    // The 'SetOrder' takes in an ADT called 'OrderParam' so need to construct it first
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      zero_address,
+      '100000',
+      side,
+      expiryBlock
+    )
+
+    const txBuyOrder1 = await callContract(
+      accounts.nftBuyer.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      "100000",
+      false,
+      false
+    )
+
+    console.log(txBuyOrder1.receipt)
+    expect(txBuyOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      zero_address,
+      '200000',
+      side,
+      expiryBlock
+    )
+
+    const txBuyOrder2 = await callContract(
+      accounts.nftBuyer.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      "200000",
+      false,
+      false
+    )
+
+    console.log(txBuyOrder2.receipt)
+    expect(txBuyOrder2.receipt.success).toEqual(true)
+
+    const fixedPriceAfterPlacingOrderBalance = await getBalance(fixedPriceAddress)
+
+    expect(fixedPriceAfterPlacingOrderBalance).toEqual(String(310000));
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      zero_address,
+      "100000",
+      side
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      zero_address,
+      "200000",
+      side
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    console.log(orderList);
+
+    const tx = await callContract(
+      accounts.nftBuyer.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Buyer cancels buy orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(true)
+
+    let events = tx.receipt.event_logs;
+    expect(events.length).toEqual(2)
+
+    expect(events[0]._eventname == 'CancelOrder').toEqual(true);
+    expect(events[1]._eventname == 'CancelOrder').toEqual(true);
+
+    expect(events[0].params[0].value).toEqual(accounts.nftBuyer.address.toLowerCase())
+    expect(events[0].params[5].value).toEqual("200000")
+
+    expect(events[1].params[0].value).toEqual(accounts.nftBuyer.address.toLowerCase())
+    expect(events[1].params[5].value).toEqual("100000")
+
+    const fixedPriceEndingBalance = await getBalance(fixedPriceAddress)
+    expect(fixedPriceEndingBalance).toEqual(fixedPriceStartingBalance);
+  })
+
+  test('BatchCancelOrder: Admin cancels sell orders', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+
+    const side = String(0)
+
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      zero_address,
+      '100000',
+      side,
+      String(globalBNum + 35)
+    )
+  
+    const txSetOrder1 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      0,
+      false,
+      false
+    )
+  
+    console.log("BatchCancelOrder: Seller cancels sell orders - 1",txSetOrder1.receipt)
+    expect(txSetOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      zero_address,
+      '200000',
+      side,
+      String(globalBNum + 35)
+    )
+
+    const txSetOrder2 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Seller cancels sell orders - 2", txSetOrder2.receipt)
+    expect(txSetOrder2.receipt.success).toEqual(true)
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      zero_address,
+      "100000",
+      side
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      zero_address,
+      "200000",
+      side
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    const pauseTx = await callContract(
+      accounts.contractOwner.privateKey,
+      fixedPriceContract,
+      "Pause",
+      [],
+      0,
+      false,
+      false
+    );
+
+    expect(pauseTx.receipt.success).toEqual(true);
+
+    const tx = await callContract(
+      accounts.contractOwner.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Seller cancels sell orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(true)
+
+    let events = tx.receipt.event_logs;
+    expect(events.length).toEqual(2)
+
+    expect(events[0]._eventname == 'CancelOrder').toEqual(true);
+    expect(events[1]._eventname == 'CancelOrder').toEqual(true);
+
+    expect(events[0].params[0].value).toEqual(accounts.nftSeller.address.toLowerCase())
+    expect(events[0].params[5].value).toEqual("200000")
+
+    expect(events[1].params[0].value).toEqual(accounts.nftSeller.address.toLowerCase())
+    expect(events[1].params[5].value).toEqual("100000")
+
+  })
+
+  test('BatchCancelOrder: Admin cancels sell orders without Pausing contract throws NotPausedError Error', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+
+    const side = String(0)
+
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      zero_address,
+      '100000',
+      side,
+      String(globalBNum + 35)
+    )
+  
+    const txSetOrder1 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      0,
+      false,
+      false
+    )
+  
+    console.log("BatchCancelOrder: Admin cancels sell orders - 1",txSetOrder1.receipt)
+    expect(txSetOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      zero_address,
+      '200000',
+      side,
+      String(globalBNum + 35)
+    )
+
+    const txSetOrder2 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Admin cancels sell orders - 2", txSetOrder2.receipt)
+    expect(txSetOrder2.receipt.success).toEqual(true)
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      zero_address,
+      "100000",
+      side
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      zero_address,
+      "200000",
+      side
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    const tx = await callContract(
+      accounts.contractOwner.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Admin cancels sell orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(false)
+    expect(tx.receipt.exceptions).toEqual([
+      {
+        line: 1,
+        message: 'Exception thrown: (Message [(_exception : (String "Error")) ; (code : (Int32 -2))])'
+      },
+      { line: 1, message: 'Raised from RequireAllowedUser' },
+      { line: 1, message: 'Raised from BatchCancelOrder' }
+    ])
+
+  })
+
+  test('BatchCancelOrder: Admin cancels buy orders', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+    const fixedPriceStartingBalance = await getBalance(fixedPriceAddress)
+
+    const side = String(1)
+    const expiryBlock = String(globalBNum + 35)
+
+    // The 'SetOrder' takes in an ADT called 'OrderParam' so need to construct it first
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      zero_address,
+      '100000',
+      side,
+      expiryBlock
+    )
+
+    const txBuyOrder1 = await callContract(
+      accounts.nftBuyer.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      "100000",
+      false,
+      false
+    )
+
+    console.log(txBuyOrder1.receipt)
+    expect(txBuyOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      zero_address,
+      '200000',
+      side,
+      expiryBlock
+    )
+
+    const txBuyOrder2 = await callContract(
+      accounts.nftBuyer.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      "200000",
+      false,
+      false
+    )
+
+    console.log(txBuyOrder2.receipt)
+    expect(txBuyOrder2.receipt.success).toEqual(true)
+
+    const fixedPriceAfterPlacingOrderBalance = await getBalance(fixedPriceAddress)
+
+    expect(fixedPriceAfterPlacingOrderBalance).toEqual(String(310000));
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      zero_address,
+      "100000",
+      side
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      zero_address,
+      "200000",
+      side
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    console.log(orderList);
+
+    const pauseTx = await callContract(
+      accounts.contractOwner.privateKey,
+      fixedPriceContract,
+      "Pause",
+      [],
+      0,
+      false,
+      false
+    );
+
+    expect(pauseTx.receipt.success).toEqual(true);
+
+    const tx = await callContract(
+      accounts.contractOwner.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Buyer cancels buy orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(true)
+
+    let events = tx.receipt.event_logs;
+    expect(events.length).toEqual(2)
+
+    expect(events[0]._eventname == 'CancelOrder').toEqual(true);
+    expect(events[1]._eventname == 'CancelOrder').toEqual(true);
+
+    expect(events[0].params[0].value).toEqual(accounts.nftBuyer.address.toLowerCase())
+    expect(events[0].params[5].value).toEqual("200000")
+
+    expect(events[1].params[0].value).toEqual(accounts.nftBuyer.address.toLowerCase())
+    expect(events[1].params[5].value).toEqual("100000")
+
+    const fixedPriceEndingBalance = await getBalance(fixedPriceAddress)
+    expect(fixedPriceEndingBalance).toEqual(fixedPriceStartingBalance);
+  })
 })
 
 describe('Wrapped ZIL', () => {
@@ -4317,6 +5069,778 @@ describe('Wrapped ZIL', () => {
     );
 
   })
+
+  test('BatchCancelOrder: Seller cancels sell orders ZRC2', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+    const side = String(0)
+
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      paymentTokenAddress,
+      '100000',
+      side,
+      String(globalBNum + 35)
+    )
+  
+    const txSetOrder1 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      0,
+      false,
+      false
+    )
+  
+    console.log("BatchCancelOrder: Seller cancels sell orders - 1",txSetOrder1.receipt)
+    expect(txSetOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      paymentTokenAddress,
+      '200000',
+      side,
+      String(globalBNum + 35)
+    )
+
+    const txSetOrder2 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Seller cancels sell orders - 2", txSetOrder2.receipt)
+    expect(txSetOrder2.receipt.success).toEqual(true)
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      paymentTokenAddress,
+      "100000",
+      side
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      paymentTokenAddress,
+      "200000",
+      side
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    console.log(orderList);
+
+    const tx = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Seller cancels sell orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(true)
+
+    let events = tx.receipt.event_logs;
+    expect(events.length).toEqual(2)
+
+    expect(events[0]._eventname == 'CancelOrder').toEqual(true);
+    expect(events[1]._eventname == 'CancelOrder').toEqual(true);
+
+    expect(events[0].params[0].value).toEqual(accounts.nftSeller.address.toLowerCase())
+    expect(events[0].params[5].value).toEqual("200000")
+
+    expect(events[1].params[0].value).toEqual(accounts.nftSeller.address.toLowerCase())
+    expect(events[1].params[5].value).toEqual("100000")
+
+  })
+
+  test('BatchCancelOrder: Stranger cancels sell orders ZRC2 throw NotAllowedToCancelOrder Error', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+    const side = String(0)
+
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      paymentTokenAddress,
+      '100000',
+      side,
+      String(globalBNum + 35)
+    )
+  
+    const txSetOrder1 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      0,
+      false,
+      false
+    )
+  
+    console.log("BatchCancelOrder: Stranger cancels sell orders - 1",txSetOrder1.receipt)
+    expect(txSetOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      paymentTokenAddress,
+      '200000',
+      side,
+      String(globalBNum + 35)
+    )
+
+    const txSetOrder2 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Stranger cancels sell orders - 2", txSetOrder2.receipt)
+    expect(txSetOrder2.receipt.success).toEqual(true)
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      paymentTokenAddress,
+      "100000",
+      side
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      paymentTokenAddress,
+      "200000",
+      side
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    console.log(orderList);
+
+    const tx = await callContract(
+      accounts.stranger.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Stranger cancels sell orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(false)
+    expect(tx.receipt.exceptions).toEqual([
+      {
+        line: 1,
+        message: 'Exception thrown: (Message [(_exception : (String "Error")) ; (code : (Int32 -12))])'
+      },
+      { line: 1, message: 'Raised from RequireNotPaused' },
+      { line: 1, message: 'Raised from RequireAllowedUser' },
+      { line: 1, message: 'Raised from BatchCancelOrder' }
+    ])
+  })
+
+  test('BatchCancelOrder: Buyer cancels buy orders ZRC2', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+
+    const fixedPriceStartingBalance = await getZRC2State(fixedPriceAddress, paymentTokenAddress)
+    const buyerStartBalance = await getZRC2State(accounts.nftBuyer.address, paymentTokenAddress)
+
+    const side = String(1)
+    const expiryBlock = String(globalBNum + 35)
+
+    // The 'SetOrder' takes in an ADT called 'OrderParam' so need to construct it first
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      paymentTokenAddress,
+      '100000',
+      side,
+      expiryBlock
+    )
+
+    console.log(formattedAdtOrder1, "formattedAdtOrder1");
+
+    const txBuyOrder1 = await callContract(
+      accounts.nftBuyer.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Buyer cancels buy orders ZRC2 - 1",txBuyOrder1.receipt)
+    expect(txBuyOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      paymentTokenAddress,
+      '200000',
+      side,
+      expiryBlock
+    )
+
+    const txBuyOrder2 = await callContract(
+      accounts.nftBuyer.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Buyer cancels buy orders ZRC2 - 2",txBuyOrder2.receipt)
+    expect(txBuyOrder2.receipt.success).toEqual(true)
+
+    const fixedPriceAfterPlacingOrderBalance = await getZRC2State(fixedPriceAddress, paymentTokenAddress)
+
+    expect(fixedPriceAfterPlacingOrderBalance).toEqual(String(310000));
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      paymentTokenAddress,
+      "100000",
+      "1"
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      paymentTokenAddress,
+      "200000",
+      "1"
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    console.log(orderList);
+
+    const tx = await callContract(
+      accounts.nftBuyer.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Buyer cancels buy orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(true)
+
+    let events = tx.receipt.event_logs;
+    expect(events.length).toEqual(4)
+
+    expect(events[0]._eventname == 'CancelOrder').toEqual(true);
+    expect(events[1]._eventname == 'CancelOrder').toEqual(true);
+    expect(events[2]._eventname == 'TransferSuccess').toEqual(true);
+    expect(events[3]._eventname == 'TransferSuccess').toEqual(true);
+
+    expect(events[0].params[0].value).toEqual(accounts.nftBuyer.address.toLowerCase())
+    expect(events[0].params[5].value).toEqual("200000")
+
+    expect(events[1].params[0].value).toEqual(accounts.nftBuyer.address.toLowerCase())
+    expect(events[1].params[5].value).toEqual("100000")
+
+    const fixedPriceEndingBalance = await getZRC2State(fixedPriceAddress, paymentTokenAddress)
+    const buyerEndBalance = await getZRC2State(accounts.nftBuyer.address, paymentTokenAddress)
+
+    console.log("fixedPriceStartingBalance", fixedPriceStartingBalance)
+    console.log("fixedPriceEndingBalance", fixedPriceEndingBalance)
+    console.log("buyerStartBalance", buyerStartBalance)
+    console.log("buyerEndBalance", buyerEndBalance)
+
+    expect(parseInt(fixedPriceEndingBalance)).toBe(parseInt(fixedPriceStartingBalance))
+    expect(parseInt(buyerEndBalance)).toBe(parseInt(buyerStartBalance))
+  })
+
+  test('BatchCancelOrder: Admin cancels sell orders ZRC2', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+    const side = String(0)
+
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      paymentTokenAddress,
+      '100000',
+      side,
+      String(globalBNum + 35)
+    )
+  
+    const txSetOrder1 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      0,
+      false,
+      false
+    )
+  
+    console.log("BatchCancelOrder: Seller cancels sell orders - 1",txSetOrder1.receipt)
+    expect(txSetOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      paymentTokenAddress,
+      '200000',
+      side,
+      String(globalBNum + 35)
+    )
+
+    const txSetOrder2 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Seller cancels sell orders - 2", txSetOrder2.receipt)
+    expect(txSetOrder2.receipt.success).toEqual(true)
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      paymentTokenAddress,
+      "100000",
+      side
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      paymentTokenAddress,
+      "200000",
+      side
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    console.log(orderList);
+
+    const pauseTx = await callContract(
+      accounts.contractOwner.privateKey,
+      fixedPriceContract,
+      "Pause",
+      [],
+      0,
+      false,
+      false
+    );
+
+    expect(pauseTx.receipt.success).toEqual(true);
+
+    const tx = await callContract(
+      accounts.contractOwner.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Seller cancels sell orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(true)
+
+    let events = tx.receipt.event_logs;
+    expect(events.length).toEqual(2)
+
+    expect(events[0]._eventname == 'CancelOrder').toEqual(true);
+    expect(events[1]._eventname == 'CancelOrder').toEqual(true);
+
+    expect(events[0].params[0].value).toEqual(accounts.nftSeller.address.toLowerCase())
+    expect(events[0].params[5].value).toEqual("200000")
+
+    expect(events[1].params[0].value).toEqual(accounts.nftSeller.address.toLowerCase())
+    expect(events[1].params[5].value).toEqual("100000")
+
+  })
+
+  test('BatchCancelOrder: Admin cancels sell orders ZRC2  without Pausing contract throws NotPausedError Error', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+    const side = String(0)
+
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      paymentTokenAddress,
+      '100000',
+      side,
+      String(globalBNum + 35)
+    )
+  
+    const txSetOrder1 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      0,
+      false,
+      false
+    )
+  
+    console.log("BatchCancelOrder: Admin cancels sell orders - 1",txSetOrder1.receipt)
+    expect(txSetOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      paymentTokenAddress,
+      '200000',
+      side,
+      String(globalBNum + 35)
+    )
+
+    const txSetOrder2 = await callContract(
+      accounts.nftSeller.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Admin cancels sell orders - 2", txSetOrder2.receipt)
+    expect(txSetOrder2.receipt.success).toEqual(true)
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      paymentTokenAddress,
+      "100000",
+      side
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      paymentTokenAddress,
+      "200000",
+      side
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    console.log(orderList);
+
+    const tx = await callContract(
+      accounts.contractOwner.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Admin cancels sell orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(false)
+    expect(tx.receipt.exceptions).toEqual([
+      {
+        line: 1,
+        message: 'Exception thrown: (Message [(_exception : (String "Error")) ; (code : (Int32 -2))])'
+      },
+      { line: 1, message: 'Raised from RequireAllowedUser' },
+      { line: 1, message: 'Raised from BatchCancelOrder' }
+    ])
+
+  })
+
+  test('BatchCancelOrder: Admin cancels buy orders ZRC2', async () => {
+    const fixedPriceContract = await zilliqa.contracts.at(fixedPriceAddress)
+
+    const fixedPriceStartingBalance = await getZRC2State(fixedPriceAddress, paymentTokenAddress)
+    const buyerStartBalance = await getZRC2State(accounts.nftBuyer.address, paymentTokenAddress)
+
+    const side = String(1)
+    const expiryBlock = String(globalBNum + 35)
+
+    // The 'SetOrder' takes in an ADT called 'OrderParam' so need to construct it first
+    const formattedAdtOrder1 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '1',
+      paymentTokenAddress,
+      '100000',
+      side,
+      expiryBlock
+    )
+
+    console.log(formattedAdtOrder1, "formattedAdtOrder1");
+
+    const txBuyOrder1 = await callContract(
+      accounts.nftBuyer.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder1
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Buyer cancels buy orders ZRC2 - 1",txBuyOrder1.receipt)
+    expect(txBuyOrder1.receipt.success).toEqual(true)
+
+    const formattedAdtOrder2 = await createFixedPriceOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      '2',
+      paymentTokenAddress,
+      '200000',
+      side,
+      expiryBlock
+    )
+
+    const txBuyOrder2 = await callContract(
+      accounts.nftBuyer.privateKey,
+      fixedPriceContract,
+      'SetOrder',
+      [
+        {
+          vname: 'order',
+          type: `${fixedPriceAddress}.OrderParam`,
+          value: formattedAdtOrder2
+        }
+      ],
+      0,
+      false,
+      false
+    )
+
+    console.log("BatchCancelOrder: Buyer cancels buy orders ZRC2 - 2",txBuyOrder2.receipt)
+    expect(txBuyOrder2.receipt.success).toEqual(true)
+
+    const fixedPriceAfterPlacingOrderBalance = await getZRC2State(fixedPriceAddress, paymentTokenAddress)
+
+    expect(fixedPriceAfterPlacingOrderBalance).toEqual(String(310000));
+
+    let orderList = [];
+
+    const formattedBatchCancelOrder1 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "1",
+      paymentTokenAddress,
+      "100000",
+      "1"
+    )
+
+    const formattedBatchCancelOrder2 = await createBatchCancelOrder(
+      fixedPriceAddress,
+      nftTokenAddress,
+      "2",
+      paymentTokenAddress,
+      "200000",
+      "1"
+    )
+
+    orderList = [formattedBatchCancelOrder1, formattedBatchCancelOrder2];
+
+    console.log(orderList);
+
+    const pauseTx = await callContract(
+      accounts.contractOwner.privateKey,
+      fixedPriceContract,
+      "Pause",
+      [],
+      0,
+      false,
+      false
+    );
+
+    expect(pauseTx.receipt.success).toEqual(true);
+
+    const tx = await callContract(
+      accounts.contractOwner.privateKey,
+      fixedPriceContract,
+      'BatchCancelOrder',
+      [
+        {
+          vname: 'cancel_order_list',
+          type: `List ${fixedPriceAddress}.CancelOrderParam`,
+          value: orderList
+        }
+      ],
+      0,
+      false,
+      false
+    )
+    console.log("BatchCancelOrder: Buyer cancels buy orders - 3",tx.receipt)
+    expect(tx.receipt.success).toEqual(true)
+
+    let events = tx.receipt.event_logs;
+    expect(events.length).toEqual(4)
+
+    expect(events[0]._eventname == 'CancelOrder').toEqual(true);
+    expect(events[1]._eventname == 'CancelOrder').toEqual(true);
+    expect(events[2]._eventname == 'TransferSuccess').toEqual(true);
+    expect(events[3]._eventname == 'TransferSuccess').toEqual(true);
+
+    expect(events[0].params[0].value).toEqual(accounts.nftBuyer.address.toLowerCase())
+    expect(events[0].params[5].value).toEqual("200000")
+
+    expect(events[1].params[0].value).toEqual(accounts.nftBuyer.address.toLowerCase())
+    expect(events[1].params[5].value).toEqual("100000")
+
+    const fixedPriceEndingBalance = await getZRC2State(fixedPriceAddress, paymentTokenAddress)
+    const buyerEndBalance = await getZRC2State(accounts.nftBuyer.address, paymentTokenAddress)
+
+    console.log("fixedPriceStartingBalance", fixedPriceStartingBalance)
+    console.log("fixedPriceEndingBalance", fixedPriceEndingBalance)
+    console.log("buyerStartBalance", buyerStartBalance)
+    console.log("buyerEndBalance", buyerEndBalance)
+
+    expect(parseInt(fixedPriceEndingBalance)).toBe(parseInt(fixedPriceStartingBalance))
+    expect(parseInt(buyerEndBalance)).toBe(parseInt(buyerStartBalance))
+  })
 })
 
 describe ('Signed Order', () => {
@@ -4934,6 +6458,7 @@ describe ('Signed Order', () => {
 
 
 })
+
 describe('Native ZIL & ZRC2', () => {
   beforeEach(async () => {
     const paymentTokenContract = await zilliqa.contracts.at(paymentTokenAddress)


### PR DESCRIPTION
The idea of this PR is to add BatchCancelOrders transition.

There is a new role introduced called Operator (In the case of Multi-Sig wallet, Admin can't call BatchCancelOrder transition due to various reasons, hence created a new role), BatchCancel can be done by the seller (for sell orders), the buyer (for buy orders), the admin & operator (for buy/sell orders).

While the seller/ buyer is trying to execute the BatchCancel transition, the contract should be in unpause status and should be in pause status while admin/operating is performing the same.

Admin can manage the operator address.